### PR TITLE
Clarifying tweaks to login file

### DIFF
--- a/login.php
+++ b/login.php
@@ -8,7 +8,7 @@ session_start();
 $provider = new TheNetworg\OAuth2\Client\Provider\Azure([
     'clientId'          => 'Register your app at apps.dev.microsoft.com',
     'clientSecret'      => 'Register your app at apps.dev.microsoft.com',
-    'redirectUri'       => 'The redirect URI you registered (I used: http://localhost/login)'
+    'redirectUri'       => 'http://localhost:8000/login.php'
 ]);
 
 // Just do basic read of /me endpoint 

--- a/login.php
+++ b/login.php
@@ -43,7 +43,8 @@ if (!isset($_GET['code'])) {
         $me = $provider->get("me", $token);
 
         // To get individual claims, you can do '$me['givenName']'
-        exit(implode("<br>", $me));
+        $values = '<pre>' . print_r($me, true) . '</pre>';
+        exit($values);
 
     } catch (Exception $e) {
         exit('Failed to call the me endpoint of MS Graph.');


### PR DESCRIPTION
Since the file is called "login.php", I think it makes sense to fill out the redirectUri as such and assume that the user won't change the filename.

I also added formatting to the /me data. If you log in with a personal account, you don't get a lot of data back, and the data you _do_ get is a little weird, so having the array keys helps the user understand what he's getting back when he calls the service.